### PR TITLE
Don't install psycopg2 for local installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Nainstalovanou aplikaci spustíš následovně:
 * (nepovinné) Aktivuj si virtuální prostředí, máš-li ho vytvořené.
 * Nainstaluj závislosti:
   ```console
-  $ python -m pip install -r requirements.txt
+  $ python -m pip install -r requirements-local.txt
   ```
 * Proveď migraci:
   ```console

--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -1,12 +1,15 @@
+certifi==2018.11.29
+chardet==3.0.4
 dj-database-url==0.5.0
 Django==2.1.7
 django-markdown2==0.3.1
 django-registration-redux==2.0
 hellowebapp-deploy==1.0.2
+idna==2.8
 markdown2==2.3.7
 mistune==0.8.4
 Pillow==5.2.0
-psycopg2==2.7.3.2
 pytz==2018.9
-waitress==1.1.0
+requests==2.21.0
+urllib3==1.24.1
 whitenoise==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,4 @@
-certifi==2018.11.29
-chardet==3.0.4
-dj-database-url==0.5.0
-Django==2.1.7
-django-markdown2==0.3.1
-django-registration-redux==2.0
+-r requirements-local.txt
 gunicorn==19.9.0
-hellowebapp-deploy==1.0.2
-idna==2.8
-markdown2==2.3.7
-mistune==0.8.4
-Pillow==5.2.0
 psycopg2==2.7.3.2
-pytz==2018.9
-requests==2.21.0
-urllib3==1.24.1
 waitress==1.1.0
-whitenoise==3.3.1


### PR DESCRIPTION
psycopg2 is not easy to install, and it is not needed with SQLite.
Heroku reads requirements.txt, so keep it there, but tell developers to install from requirements-local.txt instead.